### PR TITLE
Changed xlab and ylab handling for glMDPlot

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Glimma
 Type: Package
 Title: Interactive HTML graphics
-Version: 1.3.21
+Version: 1.3.22
 Date: 2016-12-21
 Author: Shian Su, Matthew E. Ritchie, Charity Law, Stuart Lee
 Maintainer: Shian Su <su.s@wehi.edu.au>

--- a/R/glMDPlot.R
+++ b/R/glMDPlot.R
@@ -252,6 +252,8 @@ glMDPlot.default <- function(x, xval, yval, counts=NULL, anno=NULL,
 #'   as the number of rows of object. If NULL, then all points are plotted in
 #'   the default colour.
 #' @param transform TRUE if counts cpm transformed.
+#' @param xlab label for x axis on left plot.
+#' @param ylab label for y axis on left plot.
 #' @param side.main the column containing mains for right plot.
 #' @param side.xlab label for x axis on right plot.
 #' @param side.ylab label for y axis on right plot.
@@ -286,6 +288,7 @@ glMDPlot.default <- function(x, xval, yval, counts=NULL, anno=NULL,
 glMDPlot.DGELRT <- function(x, counts=NULL, anno=NULL,
                             groups=NULL, samples=NULL,
                             status=rep(0, nrow(x)), transform=FALSE,
+							xlab="Average log CPM", ylab="log-fold-change",
                             side.xlab="Group", side.ylab="Expression",
                             side.log=FALSE,
                             side.gridstep=ifelse(!transform || side.log, FALSE, 0.5),
@@ -393,7 +396,7 @@ glMDPlot.DGELRT <- function(x, counts=NULL, anno=NULL,
                 side.main=side.main, default.col=cols[2], jitter=jitter,
                 path=path, folder=folder, html=html, launch=launch,
                 xval=xval, yval=yval,
-                xlab="Average log CPM", ylab="log-fold-change",
+                xlab=xlab, ylab=ylab,
                 side.xlab=side.xlab, side.ylab=side.ylab, side.log=side.log,
                 side.gridstep=side.gridstep,
                 ...)
@@ -473,6 +476,7 @@ glMDPlot.DGEExact <- glMDPlot.DGELRT
 glMDPlot.MArrayLM <- function(x, counts=NULL, anno=NULL,
                             groups=NULL, samples=NULL,
                             status=rep(0, nrow(x)), transform=FALSE,
+					    	xlab="Average log CPM", ylab="log-fold-change",
                             side.main="GeneID",
                             side.xlab="Group", side.ylab="Expression",
                             side.log=FALSE,
@@ -596,7 +600,7 @@ glMDPlot.MArrayLM <- function(x, counts=NULL, anno=NULL,
                 side.main=side.main, default.col=cols[2], jitter=jitter,
                 path=path, folder=folder, html=html, launch=launch,
                 xval=xval, yval=yval,
-                xlab="Average log CPM", ylab="log-fold-change",
+                xlab=xlab, ylab=ylab,
                 side.xlab=side.xlab, side.ylab=side.ylab, side.log=side.log,
                 side.gridstep=side.gridstep,
                 ...)
@@ -617,6 +621,8 @@ glMDPlot.MArrayLM <- function(x, counts=NULL, anno=NULL,
 #'   as the number of rows of object. If NULL, then all points are plotted in
 #'   the default colour.
 #' @param transform TRUE if counts cpm transformed.
+#' @param xlab label for x axis on left plot.
+#' @param ylab label for y axis on left plot.
 #' @param side.main the column containing mains for right plot.
 #' @param side.xlab label for x axis on right plot.
 #' @param side.ylab label for y axis on right plot.
@@ -649,6 +655,7 @@ glMDPlot.MArrayLM <- function(x, counts=NULL, anno=NULL,
 
 glMDPlot.DESeqDataSet <- function(x, counts=NULL, anno, groups, samples=NULL,
                                 status=rep(0, nrow(x)), transform=FALSE,
+						    	xlab="Mean Expression", ylab="log-fold-change",
                                 side.xlab="Group", side.ylab="logMean",
                                 side.log=FALSE,
                                 side.gridstep=ifelse(!transform || side.log, FALSE, 0.5),
@@ -733,7 +740,7 @@ glMDPlot.DESeqDataSet <- function(x, counts=NULL, anno, groups, samples=NULL,
                     side.main=side.main, default.col=cols[2], jitter=jitter,
                     path=path, folder=folder, html=html, launch=launch,
                     xval=xval, yval=yval,
-                    xlab="Mean Expression", ylab="log-fold-change",
+                    xlab=xlab, ylab=ylab,
                     side.xlab=side.xlab, side.ylab=side.ylab, side.log=side.log,
                     side.gridstep=side.gridstep,
                     ...)
@@ -759,6 +766,7 @@ glMDPlot.DESeqDataSet <- function(x, counts=NULL, anno, groups, samples=NULL,
 
 glMDPlot.DESeqResults <- function(x, counts, anno, groups, samples=NULL,
                                 status=rep(0, nrow(x)), transform=FALSE,
+							  	xlab="Mean Expression", ylab="log-fold-change",
                                 side.xlab="Group", side.ylab="Expression",
                                 side.log=FALSE,
                                 side.gridstep=ifelse(!transform || side.log, FALSE, 0.5),
@@ -844,7 +852,7 @@ glMDPlot.DESeqResults <- function(x, counts, anno, groups, samples=NULL,
                     side.main=side.main, default.col=cols[2], jitter=jitter,
                     path=path, folder=folder, html=html, launch=launch,
                     xval=xval, yval=yval,
-                    xlab="Mean Expression", ylab="log-fold-change",
+                    xlab=xlab, ylab=ylab,
                     side.xlab=side.xlab, side.ylab=side.ylab, side.log=side.log,
                     side.gridstep=side.gridstep,
                     ...)

--- a/man/glMDPlot.DESeqDataSet.Rd
+++ b/man/glMDPlot.DESeqDataSet.Rd
@@ -6,7 +6,8 @@
 \usage{
 \method{glMDPlot}{DESeqDataSet}(x, counts = NULL, anno, groups,
   samples = NULL, status = rep(0, nrow(x)), transform = FALSE,
-  side.xlab = "Group", side.ylab = "logMean", side.log = FALSE,
+  xlab = "Mean Expression", ylab = "log-fold-change", side.xlab = "Group",
+  side.ylab = "logMean", side.log = FALSE,
   side.gridstep = ifelse(!transform || side.log, FALSE, 0.5), jitter = 30,
   side.main = "GeneID", display.columns = NULL, cols = c("#00bfff",
   "#858585", "#ff3030"), sample.cols = rep("#1f77b4", ncol(x)),
@@ -29,6 +30,10 @@ as the number of rows of object. If NULL, then all points are plotted in
 the default colour.}
 
 \item{transform}{TRUE if counts cpm transformed.}
+
+\item{xlab}{label for x axis on left plot.}
+
+\item{ylab}{label for y axis on left plot.}
 
 \item{side.xlab}{label for x axis on right plot.}
 

--- a/man/glMDPlot.DESeqResults.Rd
+++ b/man/glMDPlot.DESeqResults.Rd
@@ -5,13 +5,13 @@
 \title{Glimma MD Plot}
 \usage{
 \method{glMDPlot}{DESeqResults}(x, counts, anno, groups, samples = NULL,
-  status = rep(0, nrow(x)), transform = FALSE, side.xlab = "Group",
-  side.ylab = "Expression", side.log = FALSE,
-  side.gridstep = ifelse(!transform || side.log, FALSE, 0.5), jitter = 30,
-  side.main = "GeneID", display.columns = NULL, cols = c("#00bfff",
-  "#858585", "#ff3030"), sample.cols = rep("#1f77b4", ncol(counts)),
-  path = getwd(), folder = "glimma-plots", html = "MD-Plot",
-  launch = TRUE, ...)
+  status = rep(0, nrow(x)), transform = FALSE, xlab = "Mean Expression",
+  ylab = "log-fold-change", side.xlab = "Group", side.ylab = "Expression",
+  side.log = FALSE, side.gridstep = ifelse(!transform || side.log, FALSE,
+  0.5), jitter = 30, side.main = "GeneID", display.columns = NULL,
+  cols = c("#00bfff", "#858585", "#ff3030"), sample.cols = rep("#1f77b4",
+  ncol(counts)), path = getwd(), folder = "glimma-plots",
+  html = "MD-Plot", launch = TRUE, ...)
 }
 \arguments{
 \item{x}{the DESeqResults object.}
@@ -29,6 +29,10 @@ as the number of rows of object. If NULL, then all points are plotted in
 the default colour.}
 
 \item{transform}{TRUE if counts cpm transformed.}
+
+\item{xlab}{label for x axis on left plot.}
+
+\item{ylab}{label for y axis on left plot.}
 
 \item{side.xlab}{label for x axis on right plot.}
 

--- a/man/glMDPlot.DGEExact.Rd
+++ b/man/glMDPlot.DGEExact.Rd
@@ -6,7 +6,8 @@
 \usage{
 \method{glMDPlot}{DGEExact}(x, counts = NULL, anno = NULL, groups = NULL,
   samples = NULL, status = rep(0, nrow(x)), transform = FALSE,
-  side.xlab = "Group", side.ylab = "Expression", side.log = FALSE,
+  xlab = "Average log CPM", ylab = "log-fold-change", side.xlab = "Group",
+  side.ylab = "Expression", side.log = FALSE,
   side.gridstep = ifelse(!transform || side.log, FALSE, 0.5),
   p.adj.method = "BH", jitter = 30, side.main = "GeneID",
   display.columns = NULL, cols = c("#00bfff", "#858585", "#ff3030"),
@@ -29,6 +30,10 @@ as the number of rows of object. If NULL, then all points are plotted in
 the default colour.}
 
 \item{transform}{TRUE if counts cpm transformed.}
+
+\item{xlab}{label for x axis on left plot.}
+
+\item{ylab}{label for y axis on left plot.}
 
 \item{side.xlab}{label for x axis on right plot.}
 

--- a/man/glMDPlot.DGELRT.Rd
+++ b/man/glMDPlot.DGELRT.Rd
@@ -6,7 +6,8 @@
 \usage{
 \method{glMDPlot}{DGELRT}(x, counts = NULL, anno = NULL, groups = NULL,
   samples = NULL, status = rep(0, nrow(x)), transform = FALSE,
-  side.xlab = "Group", side.ylab = "Expression", side.log = FALSE,
+  xlab = "Average log CPM", ylab = "log-fold-change", side.xlab = "Group",
+  side.ylab = "Expression", side.log = FALSE,
   side.gridstep = ifelse(!transform || side.log, FALSE, 0.5),
   p.adj.method = "BH", jitter = 30, side.main = "GeneID",
   display.columns = NULL, cols = c("#00bfff", "#858585", "#ff3030"),
@@ -29,6 +30,10 @@ as the number of rows of object. If NULL, then all points are plotted in
 the default colour.}
 
 \item{transform}{TRUE if counts cpm transformed.}
+
+\item{xlab}{label for x axis on left plot.}
+
+\item{ylab}{label for y axis on left plot.}
 
 \item{side.xlab}{label for x axis on right plot.}
 

--- a/man/glMDPlot.MArrayLM.Rd
+++ b/man/glMDPlot.MArrayLM.Rd
@@ -6,6 +6,7 @@
 \usage{
 \method{glMDPlot}{MArrayLM}(x, counts = NULL, anno = NULL, groups = NULL,
   samples = NULL, status = rep(0, nrow(x)), transform = FALSE,
+  xlab = "Average log CPM", ylab = "log-fold-change",
   side.main = "GeneID", side.xlab = "Group", side.ylab = "Expression",
   side.log = FALSE, side.gridstep = ifelse(!transform || side.log, FALSE,
   0.5), coef = ncol(x$coefficients), p.adj.method = "BH", jitter = 30,
@@ -29,6 +30,10 @@ as the number of rows of object. If NULL, then all points are plotted in
 the default colour.}
 
 \item{transform}{TRUE if counts cpm transformed.}
+
+\item{xlab}{label for x axis on left plot.}
+
+\item{ylab}{label for y axis on left plot.}
 
 \item{side.main}{the column containing mains for right plot.}
 

--- a/tests/testthat/test-glMDPlot.R
+++ b/tests/testthat/test-glMDPlot.R
@@ -20,6 +20,11 @@ test_that("MD Plot runs for MArrayLM", {
 
     expect_silent(glMDPlot(fit, counts=counts, anno=geneanno, launch=FALSE))
 
+    expect_silent(glMDPlot(fit, counts=counts, anno=geneanno,
+    					   xlab="foo", ylab="bar", launch=FALSE))
+    expect_silent(glMDPlot(fit, counts=counts, anno=geneanno,
+    					   side.xlab="foo", side.ylab="bar", launch=FALSE))
+
     expect_silent(
         glMDPlot(fit, counts=counts, anno=geneanno, groups=genotypes,
             display.columns=display.columns, launch=FALSE))
@@ -42,9 +47,12 @@ test_that("MD Plot runs for DGELRT", {
 
     expect_silent(glMDPlot(qlf, anno=geneanno, main="MDPlot", launch=FALSE))
 
-    expect_silent(glMDPlot(qlf, anno=geneanno, main="MDPlot", launch=FALSE))
-
     expect_warning(glMDPlot(qlf, counts=counts, main="MDPlot", launch=FALSE))
+
+    expect_silent(glMDPlot(qlf, anno=geneanno, main="MDPlot",
+    					   xlab="foo", ylab="bar", launch=FALSE))
+    expect_silent(glMDPlot(qlf, anno=geneanno, main="MDPlot",
+    					   side.xlab="foo", side.ylab="bar", launch=FALSE))
 
     expect_silent(glMDPlot(qlf, counts=counts, anno=geneanno,
             samples=1:6, status=is.de, main="MDPlot", launch=FALSE))
@@ -67,6 +75,10 @@ test_that("MD Plot runs for DGEExact", {
     display.columns <- c("Symbols", "GeneID")
 
     expect_silent(glMDPlot(et, main="MDPlot", launch=FALSE))
+    expect_silent(glMDPlot(et, main="MDPlot",
+    					   xlab="foo", ylab="bar", launch=FALSE))
+    expect_silent(glMDPlot(et, main="MDPlot",
+    					   side.xlab="foo", side.ylab="bar", launch=FALSE))
 
     expect_silent(glMDPlot(et, counts=counts,
         samples=1:6, status=is.de, main="MDPlot", launch=FALSE))


### PR DESCRIPTION
Properly added xlab and ylab arguments to glMDPlot. Previously working under the false assumption that these would not need to be changed by user.