### PR TITLE
bug fix for removing bad data

### DIFF
--- a/R/glMDSPlot.R
+++ b/R/glMDSPlot.R
@@ -75,7 +75,7 @@ glMDSPlot.default <- function(
     bad <- rowSums(is.finite(x)) < nsamples
 
     if (any(bad)) {
-        x <- x[!bad, drop=FALSE]
+        x <- x[!bad, , drop=FALSE]
     }
 
     nprobes <- nrow(x)


### PR DESCRIPTION
glMDSPlot.default checks for any non-finite data and attempts to remove rows with any non-finite values. However, the code was missing a comma in the subsetting brackets, turning the data matrix into a numeric vector. 
was: x <- x[!bad, drop = FALSE]
now: x <- x[!bad,  , drop=FALSE]