### PR TITLE
make glMDSPlot.DGEList's default prior.count = 2

### DIFF
--- a/R/glMDSPlot.R
+++ b/R/glMDSPlot.R
@@ -203,7 +203,7 @@ glMDSPlot.DGEList <- function (
     labels = NULL,
     groups = rep(1, ncol(x)),
     gene.selection = c("pairwise", "common"),
-    prior.count = 0.25,
+    prior.count = 2,
     main = "MDS Plot",
     path = getwd(),
     folder = "glimma-plots",


### PR DESCRIPTION
edgeR's plotMDS.DGEList changed the default value of prior.count from 0.25 to 2. It took me a while to figure out why glMDSPlot.DGEList was giving me a different clustering with what I thought was the same call. I propose changing glMDSPlot.DGEList's default for prior.count to 2 as well. I don't know if there are any other functions with the prior.count argument...